### PR TITLE
create the custom VM form

### DIFF
--- a/moc_ui/dicts.py
+++ b/moc_ui/dicts.py
@@ -10,11 +10,16 @@ sample_modal = {'id': 'createUser', 'action': '/register', 'method': 'post', 'ti
 login_buttons = [{'name': 'Login', 'type': 'submit', 'action': '/login/', 'class': 'btn-primary'},
 {'name': 'Register', 'type': 'modal', 'data_target': '#createUser', 'class': 'btn-success'}] 
 
-
 login_data = {'name': 'MassOpenCloud Login', 'action': '/login', 'method': 'post', 'button_list': login_buttons} 
 
-reg_modal = {'id': 'createUser', 'action': '/register', 'method': 'post', 'title': 'Register User'} 
+reg_modal = {'id': 'createUser', 'action': '/register', 'method': 'post', 'title': 'Register User'}
 
+#CONTROL PAGE
+vm_buttons = {'name': 'Create', 'type': 'modal', 'data_target': '#createVM', 'class': 'btn-success'}
+
+vm_data = {'name': 'Create a VM', 'action': '/createVM', 'method': 'post', 'button_list': vm_buttons} 
+
+vm_modal = {'id': 'create VM', 'action': '/createVM', 'method': 'post', 'title': 'Create a New VM'} 
 
 # CLOUDS PAGE
 test_vm_list_1 = [{'name': 'hadoop master', 'state': '=)', 'provider': 'HU-prod', 'image': 'centOS 7'},

--- a/moc_ui/forms.py
+++ b/moc_ui/forms.py
@@ -180,11 +180,10 @@ class ClusterProject(forms.ModelForm):
 
 # vm actions
 class Create_VM(forms.Form):
-    name = forms.CharField()
-    cluster_projects = []
-    for p in models.ClusterProject.objects.all().values('name').distinct(): #for all 
-        cluster_projects.append((p['name'], p['name']))
-    cluster_project = forms.ChoiceField(widget=forms.Select, choices=cluster_projects)
+    name   = forms.CharField()
+    image  = forms.CharField()
+    flavor = forms.CharField()
+    nics   = forms.CharField()
 
     #nova = api.get_nova(request, project)	#get nova object
 

--- a/moc_ui/html_helpers.py
+++ b/moc_ui/html_helpers.py
@@ -13,8 +13,12 @@ def project_modals(request):
              {'id':'add_Cluster_Project', 'action':'/create/ClusterProject', 
               'title':'Add Cluster Project', 'form':forms.ClusterProject()},
              {'id':'delete_Cluster_Project', 'action':'/delete/ClusterProject', 
-              'title':'Delete Cluster Project', 'form':forms.ClusterProject()},
-               #{'id':'createVM', 'title':'Create VM', 'form':forms.create_VM()},
-             {'id':'deleteVM', 'action':'/delete/Cluster', 
-              'title':'Delete VM', 'form':forms.Delete_VM()},
+              'title':'Delete Cluster Project', 'form':forms.ClusterProject()}
+            
+            ]
+def vm_modals(request):
+   return   [{'id':'createVM', 'action' : '/createVM',
+              'title':'Create VM', 'form':forms.Create_VM()},
+             {'id':'deleteVM', 'action':'/deleteVM', 
+              'title':'Delete VM', 'form':forms.Delete_VM()}
             ]

--- a/moc_ui/templates/control.html
+++ b/moc_ui/templates/control.html
@@ -50,9 +50,10 @@
 
                             <!-- Custom VM -->
 			                
-                           <!--  <a href="/VM_add/{{project}}/{{VMname}}/{{imageName}}/{{flavorName}}" class="btn btn-default btn-success" aria-label:"leftalign">
-				                <span class="glyphicon glyphicon-star" aria-hidden="true"></span>
-			                </a> -->
+                            <button type='button' data-toggle="modal" data-target="#createVM" 
+                                class="btn btn-success" aria-label="Left">
+                                    <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>Create VM
+                            </button>
 
                             <!-- Default VM -->
 			                <a href="/VM_add_default/{{project}}" class="btn btn-default btn-success" aria-label:"leftalign">
@@ -125,11 +126,9 @@
         </div>
     </div>
 
-    {% for form_data in cloud_modals %}
-        {% include "modals/cloudModal.html" %}
+    {% for form_data in vm_modals %}
+        {% include "modals/projectModal.html" %}
     {% endfor %}
-
-    {% include "modals/createVM.html" %}
 
 </div>
 {% endfor %}

--- a/moc_ui/urls.py
+++ b/moc_ui/urls.py
@@ -48,7 +48,7 @@ urlpatterns += patterns('',
     url(r'^create/(?P<object_class>.+)', create_object),
     url(r'^delete/(?P<object_class>.+)', delete_object),
     # VM creatoin
-    url(r'^VM_add', VM_add),
+    url(r'^createVM\/(?P<project>.+)?\/$', create_VM),
     # projects control
 #    url(r'^createProject', createProject),
 #    url(r'^deleteProject', deleteProject),

--- a/moc_ui/views.py
+++ b/moc_ui/views.py
@@ -69,7 +69,9 @@ def control(request, project):
 
     return render(request, 'control.html', 
                   {'project': [project], 'vms': vms,
-                   'createVMform': createVMform })
+                   'createVMform': createVMform,
+                   'vm_modals': html.vm_modals(request)
+                    })
 ## Network Page
 def network(request, project):
     createVMform = forms.Create_VM()   
@@ -80,65 +82,7 @@ def network(request, project):
                     'createVMform': createVMform })
 
 
-# VM CONTROLS
-def VM_active_state_toggle (request, project, VMid):
-    print  (project, VMid)
-    print  VMid[len(VMid)-1]
-    print  VMid[:len(VMid)-1]
-    if VMid[len(VMid)-1] == '/':
-        VMid = VMid[:len(VMid)-1]
-    nova = api.get_nova(request, project)
-    api.VM_active_state_toggle(nova, VMid)
-    return HttpResponseRedirect('/control/' + project + '/')
 
-# VM Delete
-def VM_delete(request, project, VMid):
-	print (project, VMid)					#debugging
-	if VMid[len(VMid)-1] == '/':			#strip ending /
-		VMid = VMid[:len(VMid)-1]
-	nova = api.get_nova(request, project)	#get nova object
-	api.delete(nova, VMid)					#delete specified Nova object
-	return HttpResponseRedirect('/control/' + project + '/')	#back to control
-
-# VM start
-def VM_start(request, project, VMid):
-	print (project, VMid)					#debugging
-	if VMid[len(VMid)-1] == '/':			#strip ending /
-		VMid = VMid[:len(VMid)-1]
-	nova = api.get_nova(request, project)	#get nova object
-	api.startVM(nova, VMid)					#start specified Nova object
-	return HttpResponseRedirect('/control/' + project + '/')	#back to control
-
-# VM stop
-def VM_stop(request, project, VMid):
-	print (project, VMid)					#debugging
-	if VMid[len(VMid)-1] == '/':			#strip ending /
-		VMid = VMid[:len(VMid)-1]
-	nova = api.get_nova(request, project)	#get nova object
-	api.stopVM(nova, VMid)					#stop specified Nova object
-	return HttpResponseRedirect('/control/' + project + '/')	#back to control
-
-# VM add default
-def VM_add_default(request, project):
-	print (project)
-	nova = api.get_nova(request, project)	#get nova object
-	api.createDefault(nova)
-	return HttpResponseRedirect('/control/' + project + '/')	#back to control
-
-# VM add custom
-def VM_add(request, project, VMname, imageName, flavorName):
-	print (project, VMname, imageName, flavorName)					#debugging
-
-#	if request.method == 'POST':
-#		form = forms.Create_VM(request.POST)
-#		if form.is_valid():
-#			print "form is valid."
-#			nameVM = form.cleaned_data['VM_name']
-#			nameFlavor 
-
-	nova = api.get_nova(request, project)	#get nova object
-	api.createVM(nova, VMname, imageName, flavorName)			#add specified Nova object
-	return HttpResponseRedirect('/control/' + project + '/')	#back to control
 
 #def login(request):
 #    """View to Login a user
@@ -447,3 +391,63 @@ def control_vm(request, action, vm_name):
     # check that the user has privalidge on vm
     # actually do the action
         pass
+
+# VM CONTROLS
+def VM_active_state_toggle (request, project, VMid):
+    print  (project, VMid)
+    print  VMid[len(VMid)-1]
+    print  VMid[:len(VMid)-1]
+    if VMid[len(VMid)-1] == '/':
+        VMid = VMid[:len(VMid)-1]
+    nova = api.get_nova(request, project)
+    api.VM_active_state_toggle(nova, VMid)
+    return HttpResponseRedirect('/control/' + project + '/')
+
+# VM Delete
+def VM_delete(request, project, VMid):
+    print (project, VMid)                   #debugging
+    if VMid[len(VMid)-1] == '/':            #strip ending /
+        VMid = VMid[:len(VMid)-1]
+    nova = api.get_nova(request, project)   #get nova object
+    api.delete(nova, VMid)                  #delete specified Nova object
+    return HttpResponseRedirect('/control/' + project + '/')    #back to control
+
+# VM start
+def VM_start(request, project, VMid):
+    print (project, VMid)                   #debugging
+    if VMid[len(VMid)-1] == '/':            #strip ending /
+        VMid = VMid[:len(VMid)-1]
+    nova = api.get_nova(request, project)   #get nova object
+    api.startVM(nova, VMid)                 #start specified Nova object
+    return HttpResponseRedirect('/control/' + project + '/')    #back to control
+
+# VM stop
+def VM_stop(request, project, VMid):
+    print (project, VMid)                   #debugging
+    if VMid[len(VMid)-1] == '/':            #strip ending /
+        VMid = VMid[:len(VMid)-1]
+    nova = api.get_nova(request, project)   #get nova object
+    api.stopVM(nova, VMid)                  #stop specified Nova object
+    return HttpResponseRedirect('/control/' + project + '/')    #back to control
+
+# VM add default
+def VM_add_default(request, project):
+    print (project)
+    nova = api.get_nova(request, project)   #get nova object
+    api.createDefault(nova)
+    return HttpResponseRedirect('/control/' + project + '/')    #back to control
+
+# VM add custom
+def create_VM(request, project):
+    if request.method == 'POST':
+      form = forms.Create_VM(request.POST)
+      if form.is_valid():
+          print "form is valid."
+          name   = form.cleaned_data['name']
+          flavor = form.cleaned_data['flavor']
+          image  = form.cleaned_data['image']
+          nics   = form.cleaned_data['nics']
+ 
+    # nova = api.get_nova(request, project)   #get nova object
+    # api.createVM(nova, VMname, imageName, flavorName)           #add specified Nova object
+    return HttpResponseRedirect('/control/' + project + '/')    #back to control


### PR DESCRIPTION
In the control.html, I am still parsing the 'projectModal.html" because I don't know if I should create a new modal html called vmModal.html or simply changed the name of the projectModal to another one that is not confusing. 

It will appear 4 input fields after a user click the create vm button in control page and they are: name (vm name) , image (such as ubuntu) , flavor, and nics (network connection and reference is here:http://docs.openstack.org/developer/python-novaclient/ref/v2/servers.html ) . We can always add more about it. 

Next step would be connecting the actual api calls in the forms.py (currently, most of api calls in the views).

